### PR TITLE
Restructure main/provider path and add plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-CSI-BlockDevices
+CSI-BlockDevices [![Build Status](http://travis-ci.org/thecodeteam/csi-blockdevices.svg?branch=master)](https://travis-ci.org/thecodeteam/csi-blockdevices)
 -------
-
-CSI-BlockDevices is an implementation of a
-[CSI](https://github.com/container-storage-interface) plugin for locally
+CSI-BlockDevices is a Container Storage Interface
+([CSI](https://github.com/container-storage-interface/spec)) plugin for locally
 attached block devices. Block devices can be exposed to the plugin by
 symlinking them into a directory, by default `/dev/disk/csi-blockdevices`. See
-sample commands for details
+sample commands for details.
 
-It is structured such that it can be compiled into a standalone golang binary
-that can be executed to meet the requirements of a CSI plugin. Furthermore, the
-core block and mount logic is separated into a `block` go package that can be
-imported for use by other programs.
+This project may be compiled as a stand-alone binary using Golang that,
+when run, provides a valid CSI endpoint. This project can also be
+vendored or built as a Golang plug-in in order to extend the functionality
+of other programs.
 
 Installation
 -------------
@@ -101,24 +100,24 @@ $ cd /dev/disk/csi-blockdevices
 $ dd if=/dev/zero of=test.img bs=1024 count=102400 #makes 100MiB disk image
 $ losetup /dev/loop0 test.img #attaches disk image to /dev/loop0
 $ ln -s /dev/loop0 # creates symlink named loop0 -> /dev/loop0
-$ csc ls
+$ csc ls -version 0.0.0
 name=loop0
-$ mkdir /mnt/test
-$ mkdir /mnt/test2
-$ csc mnt -mode 1 -t xfs -targetPath /mnt/test id=loop0
+$ touch /mnt/test
+$ touch /mnt/test2
+$ csc mnt -version 0.0.0 -mode 1 -t xfs -targetPath /mnt/test id=loop0
 $ cat /proc/mounts | grep loop
 /dev/loop0 /dev/disk/csi-blockdevices/.mounts/loop0 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
 /dev/loop0 /mnt/test xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
-$ csc mnt -mode 1 -t xfs -targetPath /mnt/test2 id=loop0
+$ csc mnt -version 0.0.0 -mode 1 -t xfs -targetPath /mnt/test2 id=loop0
 $ cat /proc/mounts | grep loop
 /dev/loop0 /dev/disk/csi-blockdevices/.mounts/loop0 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
 /dev/loop0 /mnt/test xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
 /dev/loop0 /mnt/test2 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
-$ csc umount -targetPath /mnt/test id=loop0
+$ csc umount -version 0.0.0 -targetPath /mnt/test id=loop0
 $ cat /proc/mounts | grep loop
 /dev/loop0 /dev/disk/csi-blockdevices/.mounts/loop0 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
 /dev/loop0 /mnt/test2 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
-$ csc umount -targetPath /mnt/test2 id=loop0
+$ csc umount -version 0.0.0 -targetPath /mnt/test2 id=loop0
 $ cat /proc/mounts | grep loop
 $
 ```

--- a/main.go
+++ b/main.go
@@ -4,109 +4,111 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/thecodeteam/csi-blockdevices/services"
 	"github.com/thecodeteam/gocsi"
-	"github.com/thecodeteam/gocsi/csi"
+
+	"github.com/thecodeteam/csi-blockdevices/provider"
+	"github.com/thecodeteam/csi-blockdevices/services"
 )
 
-const (
-	debugEnvVar = "X_CSI_BD_DEBUG"
-	nodeEnvVar  = "X_CSI_BD_NODEONLY"
-	ctlrEnvVar  = "X_CSI_BD_CONTROLLERONLY"
-)
-
+// main is ignored when this package is built as a go plug-in
 func main() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
-
-	if _, d := os.LookupEnv(debugEnvVar); d {
-		log.SetLevel(log.DebugLevel)
-	}
-
-	s := &sp{}
-
-	go func() {
-		_ = <-c
-		if s.server != nil {
-			log.WithField("name", services.SpName).Info(".GracefulStop")
-			s.server.GracefulStop()
-
-			// make sure sock file got cleaned up
-			proto, addr, _ := gocsi.GetCSIEndpoint()
-			if proto == "unix" && addr != "" {
-				if _, err := os.Stat(addr); !os.IsNotExist(err) {
-					s.server.Stop()
-					if err := os.Remove(addr); err != nil {
-						log.WithError(err).Warn(
-							"Unable to remove sock file")
-					}
-				}
-			}
-		}
-	}()
-
 	l, err := gocsi.GetCSIEndpointListener()
 	if err != nil {
-		log.WithError(err).Fatal("failed to listen")
+		log.WithError(err).Fatalln("failed to listen")
 	}
 
-	ctx := context.Background()
-
-	if err := s.Serve(ctx, l); err != nil {
-		if err != grpc.ErrServerStopped {
-			log.WithError(err).Fatal("grpc failed")
+	// Define a lambda that can be used in the exit handler
+	// to remove a potential UNIX sock file.
+	rmSockFile := func() {
+		if l == nil || l.Addr() == nil {
+			return
+		}
+		if l.Addr().Network() == "unix" {
+			sockFile := l.Addr().String()
+			os.RemoveAll(sockFile)
+			log.WithField("path", sockFile).Info("removed sock file")
 		}
 	}
+
+	sp := provider.New(nil, newGrpcInterceptors())
+	ctx := context.Background()
+
+	trapSignals(func() {
+		sp.GracefulStop(ctx)
+		rmSockFile()
+		log.Info("server stopped gracefully")
+	}, func() {
+		sp.Stop(ctx)
+		rmSockFile()
+		log.Info("server aborted")
+	})
+
+	if err := sp.Serve(ctx, l); err != nil {
+		log.WithError(err).Fatal("grpc failed")
+		os.Exit(1)
+	}
 }
 
-type sp struct {
-	server *grpc.Server
-	plugin *services.StoragePlugin
-}
-
-// ServiceProvider.Serve
-func (s *sp) Serve(ctx context.Context, li net.Listener) error {
-	log.WithField("name", services.SpName).Info(".Serve")
-	s.server = grpc.NewServer(grpc.UnaryInterceptor(gocsi.ChainUnaryServer(
+func newGrpcInterceptors() []grpc.UnaryServerInterceptor {
+	return []grpc.UnaryServerInterceptor{
 		gocsi.ServerRequestIDInjector,
 		gocsi.NewServerRequestLogger(os.Stdout, os.Stderr),
 		gocsi.NewServerResponseLogger(os.Stdout, os.Stderr),
 		gocsi.NewServerRequestVersionValidator(services.CSIVersions),
-		gocsi.ServerRequestValidator)))
-
-	s.plugin = &services.StoragePlugin{}
-	s.plugin.Init()
-
-	// Always host the Identity Service
-	csi.RegisterIdentityServer(s.server, s.plugin)
-
-	_, nodeSvc := os.LookupEnv(nodeEnvVar)
-	_, ctrlSvc := os.LookupEnv(ctlrEnvVar)
-
-	if nodeSvc && ctrlSvc {
-		log.Fatalf("Cannot specify both %s and %s",
-			nodeEnvVar, ctlrEnvVar)
+		gocsi.ServerRequestValidator,
 	}
+}
 
-	switch {
-	case nodeSvc:
-		csi.RegisterNodeServer(s.server, s.plugin)
-		log.Debug("Added Node Service")
-	case ctrlSvc:
-		csi.RegisterControllerServer(s.server, s.plugin)
-		log.Debug("Added Controller Service")
+type serviceProvider interface {
+	Serve(ctx context.Context, lis net.Listener) error
+	Stop(ctx context.Context)
+	GracefulStop(ctx context.Context)
+}
+
+func trapSignals(onExit, onAbort func()) {
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc)
+	go func() {
+		for s := range sigc {
+			ok, graceful := isExitSignal(s)
+			if !ok {
+				continue
+			}
+			if !graceful {
+				log.WithField("signal", s).Error("received signal; aborting")
+				if onAbort != nil {
+					onAbort()
+				}
+				os.Exit(1)
+			}
+			log.WithField("signal", s).Info("received signal; shutting down")
+			if onExit != nil {
+				onExit()
+			}
+			os.Exit(0)
+		}
+	}()
+}
+
+// isExitSignal returns a flag indicating whether a signal is SIGKILL, SIGHUP,
+// SIGINT, SIGTERM, or SIGQUIT. The second return value is whether it is a
+// graceful exit. This flag is true for SIGTERM, SIGHUP, SIGINT, and SIGQUIT.
+func isExitSignal(s os.Signal) (bool, bool) {
+	switch s {
+	case syscall.SIGKILL:
+		return true, false
+	case syscall.SIGTERM,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT:
+		return true, true
 	default:
-		csi.RegisterControllerServer(s.server, s.plugin)
-		log.Debug("Added Controller Service")
-		csi.RegisterNodeServer(s.server, s.plugin)
-		log.Debug("Added Node Service")
+		return false, false
 	}
-
-	// start the grpc server
-	return s.server.Serve(li)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,19 @@
+// +build linux,plugin
+
+package main
+
+import "C"
+
+import (
+	"github.com/thecodeteam/csi-blockdevices/provider"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//                              Go Plug-in                                    //
+////////////////////////////////////////////////////////////////////////////////
+
+// ServiceProviders is an exported symbol that provides a host program
+// with a map of the service provider names and constructors.
+var ServiceProviders = map[string]func() interface{}{
+	name: func() interface{} { return provider.New() },
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -8,40 +8,97 @@ import (
 	"os"
 	"sync"
 
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
 	"github.com/thecodeteam/gocsi"
 	"github.com/thecodeteam/gocsi/csi"
 	"github.com/thecodeteam/goioc"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 
 	"github.com/thecodeteam/csi-blockdevices/services"
 )
 
 const (
-	nodeEnvVar = "X_CSI_BD_NODEONLY"
-	ctlrEnvVar = "X_CSI_BDCONTROLLERONLY"
+	debugEnvVar = "X_CSI_BD_DEBUG"
+	nodeEnvVar  = "X_CSI_BD_NODEONLY"
+	ctlrEnvVar  = "X_CSI_BD_CONTROLLERONLY"
 )
 
 var (
-	errServerStarted = errors.New(
-		services.SpName + ": the server has been started")
-	errServerStopped = errors.New(
-		services.SpName + ": the server has been stopped")
+	errServerStopped = errors.New("server stopped")
+	errServerStarted = errors.New("server started")
 )
 
+// ServiceProvider is a gRPC endpoint that provides the CSI
+// services: Controller, Identity, Node.
+type ServiceProvider interface {
+
+	// Serve accepts incoming connections on the listener lis, creating
+	// a new ServerTransport and service goroutine for each. The service
+	// goroutine read gRPC requests and then call the registered handlers
+	// to reply to them. Serve returns when lis.Accept fails with fatal
+	// errors.  lis will be closed when this method returns.
+	// Serve always returns non-nil error.
+	Serve(ctx context.Context, lis net.Listener) error
+
+	// Stop stops the gRPC server. It immediately closes all open
+	// connections and listeners.
+	// It cancels all active RPCs on the server side and the corresponding
+	// pending RPCs on the client side will get notified by connection
+	// errors.
+	Stop(ctx context.Context)
+
+	// GracefulStop stops the gRPC server gracefully. It stops the server
+	// from accepting new connections and RPCs and blocks until all the
+	// pending RPCs are finished.
+	GracefulStop(ctx context.Context)
+}
+
 func init() {
-	goioc.Register(services.SpName, newProvider)
+	goioc.Register(services.Name, func() interface{} { return &provider{} })
+}
+
+// New returns a new service provider.
+func New(
+	opts []grpc.ServerOption,
+	interceptors []grpc.UnaryServerInterceptor) ServiceProvider {
+
+	return &provider{interceptors: interceptors, serverOpts: opts}
 }
 
 type provider struct {
 	sync.Mutex
-	server *grpc.Server
-	closed bool
-	plugin *services.StoragePlugin
+	server       *grpc.Server
+	closed       bool
+	service      services.Service
+	interceptors []grpc.UnaryServerInterceptor
+	serverOpts   []grpc.ServerOption
 }
 
-func newProvider() interface{} {
-	return &provider{}
+// config is an interface that matches a possible config object that
+// could possibly be pulled out of the context given to the provider's
+// Serve function
+type config interface {
+	GetString(key string) string
+}
+
+func (p *provider) newGrpcServer() *grpc.Server {
+
+	var interceptors []grpc.UnaryServerInterceptor
+	if len(p.interceptors) > 0 {
+		interceptors = append(interceptors, p.interceptors...)
+	}
+
+	iopt := gocsi.ChainUnaryServer(interceptors...)
+
+	var serverOpts []grpc.ServerOption
+	if len(p.serverOpts) > 0 {
+		serverOpts = append(serverOpts, p.serverOpts...)
+	}
+
+	serverOpts = append(serverOpts, grpc.UnaryInterceptor(iopt))
+
+	return grpc.NewServer(serverOpts...)
 }
 
 // Serve accepts incoming connections on the listener lis, creating
@@ -51,7 +108,6 @@ func newProvider() interface{} {
 // errors.  lis will be closed when this method returns.
 // Serve always returns non-nil error.
 func (p *provider) Serve(ctx context.Context, li net.Listener) error {
-	log.WithField("name", services.SpName).Info(".Serve")
 	if err := func() error {
 		p.Lock()
 		defer p.Unlock()
@@ -61,23 +117,20 @@ func (p *provider) Serve(ctx context.Context, li net.Listener) error {
 		if p.server != nil {
 			return errServerStarted
 		}
-		p.server = grpc.NewServer(
-			grpc.UnaryInterceptor(gocsi.ChainUnaryServer(
-				gocsi.ServerRequestIDInjector,
-				gocsi.NewServerRequestLogger(os.Stdout, os.Stderr),
-				gocsi.NewServerResponseLogger(os.Stdout, os.Stderr),
-				gocsi.NewServerRequestVersionValidator(services.CSIVersions),
-				gocsi.ServerRequestValidator)))
+		p.server = p.newGrpcServer()
 		return nil
 	}(); err != nil {
 		return errServerStarted
 	}
 
-	p.plugin = &services.StoragePlugin{}
-	p.plugin.Init()
+	if _, d := os.LookupEnv(debugEnvVar); d {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	p.service = services.New()
 
 	// Always host the Identity Service
-	csi.RegisterIdentityServer(p.server, p.plugin)
+	csi.RegisterIdentityServer(p.server, p.service)
 
 	_, nodeSvc := os.LookupEnv(nodeEnvVar)
 	_, ctrlSvc := os.LookupEnv(ctlrEnvVar)
@@ -91,19 +144,24 @@ func (p *provider) Serve(ctx context.Context, li net.Listener) error {
 
 	switch {
 	case nodeSvc:
-		csi.RegisterNodeServer(p.server, p.plugin)
+		csi.RegisterNodeServer(p.server, p.service)
 		log.Debug("Added Node Service")
 	case ctrlSvc:
-		csi.RegisterControllerServer(p.server, p.plugin)
+		csi.RegisterControllerServer(p.server, p.service)
 		log.Debug("Added Controller Service")
 	default:
-		csi.RegisterControllerServer(p.server, p.plugin)
+		csi.RegisterControllerServer(p.server, p.service)
 		log.Debug("Added Controller Service")
-		csi.RegisterNodeServer(p.server, p.plugin)
+		csi.RegisterNodeServer(p.server, p.service)
 		log.Debug("Added Node Service")
 	}
 
-	// start the grpc server
+	// Start the grpc server
+	log.WithFields(map[string]interface{}{
+		"service": services.Name,
+		"address": fmt.Sprintf(
+			"%s://%s", li.Addr().Network(), li.Addr().String()),
+	}).Info("serving")
 	return p.server.Serve(li)
 }
 
@@ -119,9 +177,9 @@ func (p *provider) Stop(ctx context.Context) {
 
 	p.Lock()
 	defer p.Unlock()
-	log.WithField("name", services.SpName).Info(".Stop")
 	p.server.Stop()
 	p.closed = true
+	log.WithField("service", services.Name).Info("stopped")
 }
 
 // GracefulStop stops the gRPC server gracefully. It stops the server
@@ -134,7 +192,7 @@ func (p *provider) GracefulStop(ctx context.Context) {
 
 	p.Lock()
 	defer p.Unlock()
-	log.WithField("name", services.SpName).Info(".GracefulStop")
 	p.server.GracefulStop()
 	p.closed = true
+	log.WithField("service", services.Name).Info("shutdown")
 }

--- a/services/identity.go
+++ b/services/identity.go
@@ -6,7 +6,7 @@ import (
 	"github.com/thecodeteam/gocsi/csi"
 )
 
-func (s *StoragePlugin) GetSupportedVersions(
+func (s *storagePlugin) GetSupportedVersions(
 	ctx context.Context,
 	req *csi.GetSupportedVersionsRequest) (
 	*csi.GetSupportedVersionsResponse, error) {
@@ -20,7 +20,7 @@ func (s *StoragePlugin) GetSupportedVersions(
 	}, nil
 }
 
-func (s *StoragePlugin) GetPluginInfo(
+func (s *storagePlugin) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (
 	*csi.GetPluginInfoResponse, error) {
@@ -28,8 +28,8 @@ func (s *StoragePlugin) GetPluginInfo(
 	return &csi.GetPluginInfoResponse{
 		Reply: &csi.GetPluginInfoResponse_Result_{
 			Result: &csi.GetPluginInfoResponse_Result{
-				Name:          SpName,
-				VendorVersion: spVersion,
+				Name:          Name,
+				VendorVersion: Version,
 				Manifest:      nil,
 			},
 		},

--- a/services/node.go
+++ b/services/node.go
@@ -5,16 +5,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+
 	"github.com/thecodeteam/gocsi"
 	"github.com/thecodeteam/gocsi/csi"
 	"github.com/thecodeteam/gocsi/mount"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 
 	"github.com/thecodeteam/csi-blockdevices/block"
 )
 
-func (s *StoragePlugin) NodePublishVolume(
+func (s *storagePlugin) NodePublishVolume(
 	ctx context.Context,
 	in *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 
@@ -67,7 +68,7 @@ func (s *StoragePlugin) NodePublishVolume(
 		"No supported volume type received"), nil
 }
 
-func (s *StoragePlugin) NodeUnpublishVolume(
+func (s *storagePlugin) NodeUnpublishVolume(
 	ctx context.Context,
 	in *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 
@@ -135,7 +136,7 @@ func (s *StoragePlugin) NodeUnpublishVolume(
 	}, nil
 }
 
-func (s *StoragePlugin) GetNodeID(
+func (s *storagePlugin) GetNodeID(
 	ctx context.Context,
 	in *csi.GetNodeIDRequest) (*csi.GetNodeIDResponse, error) {
 
@@ -148,7 +149,7 @@ func (s *StoragePlugin) GetNodeID(
 	}, nil
 }
 
-func (s *StoragePlugin) ProbeNode(
+func (s *storagePlugin) ProbeNode(
 	ctx context.Context,
 	in *csi.ProbeNodeRequest) (*csi.ProbeNodeResponse, error) {
 
@@ -165,7 +166,7 @@ func (s *StoragePlugin) ProbeNode(
 	}, nil
 }
 
-func (s *StoragePlugin) NodeGetCapabilities(
+func (s *storagePlugin) NodeGetCapabilities(
 	ctx context.Context,
 	in *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 
@@ -193,7 +194,7 @@ func mkdir(path string) (bool, error) {
 	return false, nil
 }
 
-func (s *StoragePlugin) handleMountVolume(
+func (s *storagePlugin) handleMountVolume(
 	dev *block.Device,
 	target string,
 	fs string,
@@ -372,11 +373,11 @@ func (s *StoragePlugin) handleMountVolume(
 	}, nil
 }
 
-func (s *StoragePlugin) getPrivateMountPoint(dev *block.Device) string {
+func (s *storagePlugin) getPrivateMountPoint(dev *block.Device) string {
 	return filepath.Join(s.privDir, dev.Name)
 }
 
-func (s *StoragePlugin) handleBlockVolume(
+func (s *storagePlugin) handleBlockVolume(
 	dev *block.Device,
 	target string) (*csi.NodePublishVolumeResponse, error) {
 
@@ -467,7 +468,7 @@ func (s *StoragePlugin) handleBlockVolume(
 	}, nil
 }
 
-func (s *StoragePlugin) unmountTarget(
+func (s *storagePlugin) unmountTarget(
 	target string) error {
 
 	if err := mount.Unmount(target); err != nil {
@@ -477,7 +478,7 @@ func (s *StoragePlugin) unmountTarget(
 	return nil
 }
 
-func (s *StoragePlugin) unmountPrivMount(
+func (s *storagePlugin) unmountPrivMount(
 	dev *block.Device,
 	target string) error {
 

--- a/services/services.go
+++ b/services/services.go
@@ -4,12 +4,14 @@ import (
 	"os"
 	"path/filepath"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/thecodeteam/gocsi/csi"
 )
 
 const (
-	SpName    = "csi-blockdevices"
-	spVersion = "0.1.0"
+	Name    = "csi-blockdevices"
+	Version = "0.1.0"
 
 	blockDirEnvVar = "X_CSI_BD_DEVDIR"
 
@@ -26,16 +28,33 @@ var (
 	}
 )
 
-type StoragePlugin struct {
+// Service is the CSI Network File System (NFS) service provider.
+type Service interface {
+	csi.ControllerServer
+	csi.IdentityServer
+	csi.NodeServer
+}
+
+// storagePlugin contains parameters for the plugin
+type storagePlugin struct {
 	DevDir  string
 	privDir string
 }
 
-func (sp *StoragePlugin) Init() {
-	sp.DevDir = defaultDevDir
+// New returns a new Service
+func New() Service {
+
+	sp := &storagePlugin{
+		DevDir: defaultDevDir,
+	}
 	if dd := os.Getenv(blockDirEnvVar); dd != "" {
 		sp.DevDir = dd
 	}
-
 	sp.privDir = filepath.Join(sp.DevDir, ".mounts")
+	log.WithFields(map[string]interface{}{
+		"devDir":  sp.DevDir,
+		"privDir": sp.privDir,
+	}).Info("created new " + Name + " service")
+
+	return sp
 }


### PR DESCRIPTION
Restructure the code so that a common path is used whether being used a
main binary (main.go) or being vendored (provider). This brings the
project inline with how CSI-VFS is structued.

Also add the plugin.go file so golang plugin builds are possible now.